### PR TITLE
Adds a default feature to allow disabling the WASM API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ clap = "4.5.30"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["wasm-api"]
+wasm-api = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use encoder::{EncoderSettings, SeaEncoder};
 mod codec;
 pub mod decoder;
 pub mod encoder;
+#[cfg(all(target_arch = "wasm32", feature = "wasm-api"))]
 pub mod wasm_api;
 
 pub fn sea_encode(

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1,9 +1,7 @@
 extern "C" {
-    #[cfg(target_arch = "wasm32")]
     fn js_error(ptr: *const std::os::raw::c_char);
 }
 
-#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn setup() {
     use std::ffi::CString;
@@ -31,7 +29,6 @@ pub extern "C" fn setup() {
     }));
 }
 
-#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn wasm_sea_encode(
     input_samples: *const i16,
@@ -67,7 +64,6 @@ pub extern "C" fn wasm_sea_encode(
     encoded_data.len()
 }
 
-#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn wasm_sea_decode(
     encoded: *const u8,
@@ -98,7 +94,6 @@ pub extern "C" fn wasm_sea_decode(
     decoded_data.samples.len() * 2
 }
 
-#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub unsafe extern "C" fn allocate(size: usize) -> *mut u8 {
     use std::alloc::{alloc, Layout};
@@ -107,7 +102,6 @@ pub unsafe extern "C" fn allocate(size: usize) -> *mut u8 {
     alloc(layout)
 }
 
-#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub unsafe extern "C" fn deallocate(ptr: *mut u8, size: usize) {
     use std::alloc::{dealloc, Layout};


### PR DESCRIPTION
- To link this crate for WASM in the "no modules" mode, the WASM API must be disabled, this PR allows for disabling the WASM API through the `wasm-api` feature 